### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ A simple application for controlling your AC with a RaspberryPi ( or a balenaFin
 ## the setup
 
 * a RaspberryPi
-* an IR receiver ( 5V tolerant, digital interface ) VCC -> 5V, GND -> GND, OUT -> GPIO23
-* an IR transmitter ( 5V tolerant, digital interface ) VCC -> 5V, GND -> GND, SIG -> GPIO22
+* an IR receiver ( 5V tolerant, digital interface ) VCC -> 5V, GND -> GND, OUT -> GPIO18
+* an IR transmitter ( 5V tolerant, digital interface ) VCC -> 5V, GND -> GND, SIG -> GPIO17
 
-the following configuration variable set: **RESIN_HOST_CONFIG_dtoverlay** = `lirc-rpi,gpio_in_pin=23,gpio_out_pin=22`
+the following configuration variable set: **RESIN_HOST_CONFIG_dtoverlay** = `gpio-ir,gpio_out_pin=17,gpio_in_pin=18,gpio_in_pull=up`
 
 ## setting up
 


### PR DESCRIPTION
latest version of raspbian changed "lirc-rpi" to "gpio-ir"
also default pins are 18/17 (could not make 23/22 work)
thus overlay should be: "gpio-ir, gpio_in_pin=18, gpio_out_pin=17, gpio_in_pull=up"